### PR TITLE
i18n: remove redundant entries

### DIFF
--- a/src/i18n/Engine.cpp
+++ b/src/i18n/Engine.cpp
@@ -19,9 +19,6 @@ void I18n::initEngine() {
     // ja_JP (Japanese)
     engine.registerEntry("ja_JP", TXT_KEY_SEARCH_SOMETHING, "検索...");
 
-    // nl_BE (Dutch Belgium)
-    engine.registerEntry("nl_BE", TXT_KEY_SEARCH_SOMETHING, "Zoeken...");
-
     // nl_NL (Dutch Netherlands)
     engine.registerEntry("nl_NL", TXT_KEY_SEARCH_SOMETHING, "Zoeken...");
 
@@ -33,9 +30,6 @@ void I18n::initEngine() {
   
     // sv_SE (Swedish)
     engine.registerEntry("sv_SE", TXT_KEY_SEARCH_SOMETHING, "Sök...");
-
-    // sv_FI (Finnish Swedish)
-    engine.registerEntry("sv_FI", TXT_KEY_SEARCH_SOMETHING, "Sök...");
 
     // vi_VN (Vietnamese)
     engine.registerEntry("vi_VN", TXT_KEY_SEARCH_SOMETHING, "Tìm kiếm...");


### PR DESCRIPTION
Removes unneeded entries, as previously discussed, to make stuff less cluttered.

```
    // zh (Simplified Chinese)
    engine.registerEntry("zh", TXT_KEY_SEARCH_SOMETHING, "搜索...");
```

Would `xy` count as fallback when looking for `xy_ANYTHING`? is it hyprutils looking for a `xy` prefix or `xy_`?