### PR TITLE
i18n: add Telugu and Punjabi translation

### DIFF
--- a/src/finders/desktop/DesktopFinder.cpp
+++ b/src/finders/desktop/DesktopFinder.cpp
@@ -129,10 +129,10 @@ void CDesktopFinder::recache() {
     m_desktopEntryCache.clear();
     m_desktopEntryCacheGeneric.clear();
 
-    std::unordered_set<std::string> desktopFileIds;
-    std::unordered_set<std::filesystem::path> directories;
+    std::unordered_set<std::string>                                                 desktopFileIds;
+    std::unordered_set<std::filesystem::path>                                       directories;
 
-    std::function<void (const std::filesystem::path&, const std::filesystem::path&)> cacheDirectory;
+    std::function<void(const std::filesystem::path&, const std::filesystem::path&)> cacheDirectory;
     cacheDirectory = [this, &cacheDirectory, &desktopFileIds, &directories](const std::filesystem::path& base, const std::filesystem::path& p) {
         std::error_code ec;
         auto            canonicalPath = std::filesystem::canonical(p, ec);
@@ -140,11 +140,13 @@ void CDesktopFinder::recache() {
             Debug::log(TRACE, "desktop: skipping {}, does not exist / already visited", p.string());
             return;
         }
-        auto            it = std::filesystem::directory_iterator(p, ec);
-        if (ec) return;
+        auto it = std::filesystem::directory_iterator(p, ec);
+        if (ec)
+            return;
         for (const auto& e : it) {
             auto status = e.status(ec);
-            if (ec) continue;
+            if (ec)
+                continue;
             if (std::filesystem::is_regular_file(status)) {
                 auto relDesktopFilePath = e.path().lexically_relative(base);
                 if (relDesktopFilePath.extension() != ".desktop") {
@@ -155,7 +157,8 @@ void CDesktopFinder::recache() {
                 std::ranges::replace(desktopFileId, '/', '-');
                 if (desktopFileIds.insert(desktopFileId).second)
                     cacheEntry(e.path());
-                else Debug::log(TRACE, "desktop: skipping entry at {}, already cached desktopFileId {}", e.path().string(), desktopFileId);
+                else
+                    Debug::log(TRACE, "desktop: skipping entry at {}, already cached desktopFileId {}", e.path().string(), desktopFileId);
             } else if (std::filesystem::is_directory(status))
                 cacheDirectory(base, e.path());
         }

--- a/src/i18n/Engine.cpp
+++ b/src/i18n/Engine.cpp
@@ -6,10 +6,10 @@ static Hyprutils::I18n::CI18nEngine engine;
 //
 void I18n::initEngine() {
     engine.setFallbackLocale("en_US");
-    
+
     // ar (Arabic)
     engine.registerEntry("ar", TXT_KEY_SEARCH_SOMETHING, "بحث...");
-    
+
     // as_IN (Assamese)
     engine.registerEntry("as_IN", TXT_KEY_SEARCH_SOMETHING, "অনুসন্ধান...");
 


### PR DESCRIPTION
Since the package already supports other major Indian languages such as Malayalam and Tamil, including Telugu and Punjabi ensures broader language coverage and supports one of the most widely spoken Indic languages. 

Telugu (te_IN) is predominantly spoken in the Indian states of Andhra Pradesh and Telangana. Punjabi (pa_IN) is widely spoken in the Indian state of Punjab and among Punjabi communities across India and abroad.
