### PR TITLE
finders/desktop: support Terminal=true applications

### DIFF
--- a/src/finders/desktop/DesktopFinder.cpp
+++ b/src/finders/desktop/DesktopFinder.cpp
@@ -239,6 +239,7 @@ void CDesktopFinder::cacheEntry(const std::filesystem::path& path) {
     const auto NAME      = extract("Name");
     const auto ICON      = extract("Icon");
     const auto EXEC      = extract("Exec");
+    const auto TERMINAL  = extract("Terminal") == "true";
     const auto NODISPLAY = extract("NoDisplay") == "true";
 
     if (EXEC.empty() || NAME.empty() || NODISPLAY) {
@@ -247,7 +248,10 @@ void CDesktopFinder::cacheEntry(const std::filesystem::path& path) {
     }
 
     auto& e       = m_desktopEntryCache.emplace_back(makeShared<CDesktopEntry>());
-    e->m_exec     = EXEC;
+    if (TERMINAL)
+        e->m_exec = std::string{"xdg-terminal-exec "}.append(EXEC);
+    else
+        e->m_exec = EXEC;
     e->m_icon     = ICON;
     e->m_name     = NAME;
     e->m_fuzzable = NAME;


### PR DESCRIPTION
This adds a new dependency, namely to [xdg-terminal-exec](https://github.com/Vladimir-csp/xdg-terminal-exec). I decided to use this script as a dependency, since, despite it still only being a proposal, there is already quite widespread use of it (e.g. wofi, [glib](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/2839)).

Since this is better than the current total lack of support it seems reasonable and it also avoids any issues caused by implementing a default list, which by its very nature will never be fully complete, or will go out of date, and will just lead to users requesting their terminal be added to the default list.