### PR TITLE
feat: Add configurable UI and item rounding options.

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -26,6 +26,8 @@ CConfigManager::CConfigManager() : m_inotifyFd(inotify_init()) {
     m_config->addConfigValue("finders:desktop_icons", Hyprlang::INT{1});
 
     m_config->addConfigValue("ui:window_size", Hyprlang::VEC2{400, 260});
+    m_config->addConfigValue("ui:rounding", Hyprlang::INT{10});
+    m_config->addConfigValue("ui:item_rounding", Hyprlang::INT{4});
 
     m_config->commence();
 

--- a/src/ui/ResultButton.cpp
+++ b/src/ui/ResultButton.cpp
@@ -2,6 +2,9 @@
 #include "../finders/IFinder.hpp"
 
 #include "UI.hpp"
+#include "../config/ConfigManager.hpp"
+
+#include <hyprlang.hpp>
 
 CResultButton::CResultButton() {
     const auto FONT_SIZE = Hyprtoolkit::CFontSize{Hyprtoolkit::CFontSize::HT_FONT_TEXT}.ptSize();
@@ -9,13 +12,15 @@ CResultButton::CResultButton() {
 
     const auto BG_HEIGHT = (FONT_SIZE * 2.F) + 4.F;
 
+    static auto PITEMROUNDING = Hyprlang::CSimpleConfigValue<Hyprlang::INT>(g_configManager->m_config.get(), "ui:item_rounding");
+
     m_background = Hyprtoolkit::CRectangleBuilder::begin()
                        ->color([]() {
                            auto c = g_ui->m_backend->getPalette()->m_colors.accent.darken(0.3F);
                            c.a    = 0.F;
                            return c;
                        })
-                       ->rounding(4)
+                       ->rounding(*PITEMROUNDING)
                        ->size({Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, Hyprtoolkit::CDynamicSize::HT_SIZE_ABSOLUTE, {1.F, BG_HEIGHT}})
                        ->commence();
 

--- a/src/ui/UI.cpp
+++ b/src/ui/UI.cpp
@@ -20,12 +20,13 @@ constexpr const char*  DEFAULT_FONT            = "Sans Serif";
 CUI::CUI(bool open) : m_openByDefault(open) {
     static auto PGRABFOCUS  = Hyprlang::CSimpleConfigValue<Hyprlang::INT>(g_configManager->m_config.get(), "general:grab_focus");
     static auto PWINDOWSIZE = Hyprlang::CSimpleConfigValue<Hyprlang::VEC2>(g_configManager->m_config.get(), "ui:window_size");
+    static auto PROUNDING  = Hyprlang::CSimpleConfigValue<Hyprlang::INT>(g_configManager->m_config.get(), "ui:rounding");
 
     m_backend = Hyprtoolkit::IBackend::create();
 
     m_background = Hyprtoolkit::CRectangleBuilder::begin()
                        ->color([this] { return m_backend->getPalette()->m_colors.background; })
-                       ->rounding(10)
+                       ->rounding(*PROUNDING)
                        ->borderColor([this] { return m_backend->getPalette()->m_colors.accent.darken(0.2F); })
                        ->borderThickness(1)
                        ->size({Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, {1, 1}})


### PR DESCRIPTION
Expose UI rounding settings to the configuration system. This allows users to customize the visual appearance of the launcher by adjusting the rounding of the main window and result items.

Added:

ui:rounding (default 10)
ui:item_rounding (default 4)

example in config:

```
hyprlauncher.conf

ui {
  rounding = 0
  item_rounding = 0
}
```

