### PR TITLE
Add missing #include <unistd.h>

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2,6 +2,8 @@
 
 #include "../helpers/Log.hpp"
 
+#include <unistd.h>
+
 #include <hyprutils/path/Path.hpp>
 
 CConfigManager::CConfigManager() : m_inotifyFd(inotify_init()) {

--- a/src/finders/desktop/DesktopFinder.cpp
+++ b/src/finders/desktop/DesktopFinder.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <sys/inotify.h>
 #include <sys/poll.h>
+#include <unistd.h>
 #include <unordered_set>
 
 #include <hyprutils/string/String.hpp>


### PR DESCRIPTION
FreeBSD clang fails to compile the code without it.

It is required by `read()`.