### PR TITLE
ui: get rounding radii from hyprtoolkit

### DIFF
--- a/src/ui/ResultButton.cpp
+++ b/src/ui/ResultButton.cpp
@@ -15,7 +15,7 @@ CResultButton::CResultButton() {
                            c.a    = 0.F;
                            return c;
                        })
-                       ->rounding(4)
+                       ->rounding(g_ui->m_backend->getPalette()->m_vars.smallRounding)
                        ->size({Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, Hyprtoolkit::CDynamicSize::HT_SIZE_ABSOLUTE, {1.F, BG_HEIGHT}})
                        ->commence();
 

--- a/src/ui/UI.cpp
+++ b/src/ui/UI.cpp
@@ -24,7 +24,7 @@ CUI::CUI(bool open) : m_openByDefault(open) {
 
     m_background = Hyprtoolkit::CRectangleBuilder::begin()
                        ->color([this] { return m_backend->getPalette()->m_colors.background; })
-                       ->rounding(10)
+                       ->rounding(m_backend->getPalette()->m_vars.bigRounding)
                        ->borderColor([this] { return m_backend->getPalette()->m_colors.accent.darken(0.2F); })
                        ->borderThickness(1)
                        ->size({Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, Hyprtoolkit::CDynamicSize::HT_SIZE_PERCENT, {1, 1}})


### PR DESCRIPTION
Actually get rounding from hyprtoolkit, since this got forgotten in #113.
This does increase the default radius for result buttons from 4px to 5px, since that is the default in hyprtoolkit. But the textbox already uses [that value](https://github.com/hyprwm/hyprtoolkit/blob/2944c4bd01134234e10aedc9d3908ce4721f7fcd/src/element/textbox/Textbox.cpp#L46-L52) so maybe its fine?