### PR TITLE
Compiler fix for rawhide gcc.   <climits> again.

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -3,6 +3,7 @@
 #include "../helpers/Log.hpp"
 
 #include <unistd.h>
+#include <climits>
 
 #include <hyprutils/path/Path.hpp>
 


### PR DESCRIPTION
This is a trivial patch to define NAME_MAX in the latest gcc compilers.
