### PR TITLE
i18n: standardize Chinese locale codes to zh_CN and zh_TW

### DIFF
--- a/src/finders/desktop/DesktopFinder.cpp
+++ b/src/finders/desktop/DesktopFinder.cpp
@@ -281,9 +281,9 @@ std::vector<SFinderResult> CDesktopFinder::getResultsForQuery(const std::string&
         if (!p)
             continue;
         results.emplace_back(SFinderResult{
-            .label  = p->m_name,
-            .icon   = *PICONSENABLED ? p->m_icon : "",
-            .result = p,
+            .label   = p->m_name,
+            .icon    = *PICONSENABLED ? p->m_icon : "",
+            .result  = p,
             .hasIcon = true,
         });
     }

--- a/src/i18n/Engine.cpp
+++ b/src/i18n/Engine.cpp
@@ -133,11 +133,11 @@ void I18n::initEngine() {
     // vi_VN (Vietnamese)
     engine.registerEntry("vi_VN", TXT_KEY_SEARCH_SOMETHING, "Tìm kiếm...");
 
-    // zh (Simplified Chinese)
-    engine.registerEntry("zh", TXT_KEY_SEARCH_SOMETHING, "搜索...");
+    // zh_CN (Simplified Chinese)
+    engine.registerEntry("zh_CN", TXT_KEY_SEARCH_SOMETHING, "搜索...");
 
-    // zh_Hant (Traditional Chinese)
-    engine.registerEntry("zh_Hant", TXT_KEY_SEARCH_SOMETHING, "搜尋...");
+    // zh_TW (Traditional Chinese)
+    engine.registerEntry("zh_TW", TXT_KEY_SEARCH_SOMETHING, "搜尋...");
 
     // ne_NP (Nepali)
     engine.registerEntry("ne_NP", TXT_KEY_SEARCH_SOMETHING, "खोज...");


### PR DESCRIPTION
This PR updates the Chinese locale keys in src/i18n/Engine.cpp to follow the standard ll_CC format used by Linux environment variables (e.g., LANG=zh_TW.UTF-8).

- Changed zh -> zh_CN (Simplified Chinese)
- Changed zh_Hant -> zh_TW (Traditional Chinese)