### PR TITLE
compile fix for upstream gcc.

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -3,6 +3,7 @@
 #include "../helpers/Log.hpp"
 
 #include <unistd.h>
+#include <climits>
 
 #include <hyprutils/path/Path.hpp>
 


### PR DESCRIPTION
Include <mutex> to help picky upstream gcc.
