### PR TITLE
finders/desktop: add terminal config option

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -26,6 +26,7 @@ CConfigManager::CConfigManager() : m_inotifyFd(inotify_init()) {
     m_config->addConfigValue("finders:font_prefix", Hyprlang::STRING{"'"});
 
     m_config->addConfigValue("finders:desktop_launch_prefix", Hyprlang::STRING{""});
+    m_config->addConfigValue("finders:desktop_terminal", Hyprlang::STRING{""});
     m_config->addConfigValue("finders:desktop_icons", Hyprlang::INT{1});
 
     m_config->addConfigValue("ui:window_size", Hyprlang::VEC2{400, 260});

--- a/src/finders/desktop/DesktopFinder.cpp
+++ b/src/finders/desktop/DesktopFinder.cpp
@@ -54,13 +54,13 @@ class CDesktopEntry : public IFinderResult {
     }
 
     virtual void run() {
-        static auto            PLAUNCHPREFIX   = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:desktop_launch_prefix");
-        static auto            PTERMINALPREFIX = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:desktop_terminal");
-        const std::string_view LAUNCH_PREFIX   = *PLAUNCHPREFIX;
-        const std::string_view TERMINAL_PREFIX = *PTERMINALPREFIX;
+        static auto            PLAUNCHPREFIX = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:desktop_launch_prefix");
+        static auto            PTERMINALEXEC = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:desktop_terminal");
+        const std::string_view LAUNCH_PREFIX = *PLAUNCHPREFIX;
+        const std::string_view TERMINAL_EXEC = *PTERMINALEXEC;
 
         auto                   toExec = std::format("{}{}{}", LAUNCH_PREFIX.empty() ? std::string{""} : std::string{LAUNCH_PREFIX} + std::string{" "},
-                                  m_terminal && !TERMINAL_PREFIX.empty() ? std::string{TERMINAL_PREFIX} + std::string{" "} : std::string{""}, m_exec);
+                                                    m_terminal && !TERMINAL_EXEC.empty() ? std::string{TERMINAL_EXEC} + std::string{" "} : std::string{""}, m_exec);
 
         Debug::log(TRACE, "Running {}", toExec);
 

--- a/src/finders/desktop/DesktopFinder.cpp
+++ b/src/finders/desktop/DesktopFinder.cpp
@@ -54,10 +54,13 @@ class CDesktopEntry : public IFinderResult {
     }
 
     virtual void run() {
-        static auto            PLAUNCHPREFIX = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:desktop_launch_prefix");
-        const std::string_view LAUNCH_PREFIX = *PLAUNCHPREFIX;
+        static auto            PLAUNCHPREFIX   = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:desktop_launch_prefix");
+        static auto            PTERMINALPREFIX = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:desktop_terminal");
+        const std::string_view LAUNCH_PREFIX   = *PLAUNCHPREFIX;
+        const std::string_view TERMINAL_PREFIX = *PTERMINALPREFIX;
 
-        auto                   toExec = std::format("{}{}", LAUNCH_PREFIX.empty() ? std::string{""} : std::string{LAUNCH_PREFIX} + std::string{" "}, m_exec);
+        auto                   toExec = std::format("{}{}{}", LAUNCH_PREFIX.empty() ? std::string{""} : std::string{LAUNCH_PREFIX} + std::string{" "},
+                                  m_terminal && !TERMINAL_PREFIX.empty() ? std::string{TERMINAL_PREFIX} + std::string{" "} : std::string{""}, m_exec);
 
         Debug::log(TRACE, "Running {}", toExec);
 
@@ -82,6 +85,7 @@ class CDesktopEntry : public IFinderResult {
     }
 
     std::string m_name, m_exec, m_icon, m_fuzzable, m_stem;
+    bool        m_terminal = false;
 
     uint32_t    m_frequency = 0;
 };
@@ -241,6 +245,7 @@ void CDesktopFinder::cacheEntry(const std::filesystem::path& path) {
     const auto ICON      = extract("Icon");
     const auto EXEC      = extract("Exec");
     const auto NODISPLAY = extract("NoDisplay") == "true";
+    const auto TERMINAL  = extract("Terminal") == "true";
 
     if (EXEC.empty() || NAME.empty() || NODISPLAY) {
         Debug::log(TRACE, "desktop: skipping entry, empty name / exec / NoDisplay");
@@ -260,6 +265,7 @@ void CDesktopFinder::cacheEntry(const std::filesystem::path& path) {
     e->m_name     = NAME;
     e->m_fuzzable = NAME;
     e->m_stem     = std::move(pathStem);
+    e->m_terminal = TERMINAL;
     std::ranges::transform(e->m_fuzzable, e->m_fuzzable.begin(), ::tolower);
     e->m_frequency = m_entryFrequencyCache->getCachedEntry(e->m_fuzzable);
     m_desktopEntryCacheGeneric.emplace_back(e);


### PR DESCRIPTION
Implemented a new config option to set the terminal to be used for opening desktop entries with Terminal=true.
The name I used for the config option is 'finders:desktop_terminal_prefix'. Let me know if it needs to be changed.

Related to PR: https://github.com/hyprwm/hyprlauncher/pull/88
Related to Issue: https://github.com/hyprwm/hyprlauncher/issues/101
