### PR TITLE
feat: add show_apps_on_open config option

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -14,6 +14,7 @@ CConfigManager::CConfigManager() : m_inotifyFd(inotify_init()) {
     m_config = makeUnique<Hyprlang::CConfig>(CFGPATH.c_str(), Hyprlang::SConfigOptions{.allowMissingConfig = true});
 
     m_config->addConfigValue("general:grab_focus", Hyprlang::INT{1});
+    m_config->addConfigValue("general:show_apps_on_open", Hyprlang::INT{0});
 
     m_config->addConfigValue("locale:override", Hyprlang::STRING{""});
 

--- a/src/finders/desktop/DesktopFinder.cpp
+++ b/src/finders/desktop/DesktopFinder.cpp
@@ -279,7 +279,30 @@ std::vector<SFinderResult> CDesktopFinder::getResultsForQuery(const std::string&
 
     std::vector<SFinderResult> results;
 
-    auto                       fuzzed = Fuzzy::getNResults(m_desktopEntryCacheGeneric, query, MAX_RESULTS_PER_FINDER);
+    if (query.empty()) {
+        // Return all entries sorted by frequency (most used first)
+        auto sorted = m_desktopEntryCacheGeneric;
+        std::stable_sort(sorted.begin(), sorted.end(), [](const SP<IFinderResult>& a, const SP<IFinderResult>& b) { return a->frequency() > b->frequency(); });
+
+        size_t count = std::min(sorted.size(), sc<size_t>(MAX_RESULTS_PER_FINDER));
+        results.reserve(count);
+
+        for (size_t i = 0; i < count; ++i) {
+            const auto p = reinterpretPointerCast<CDesktopEntry>(sorted[i]);
+            if (!p)
+                continue;
+            results.emplace_back(SFinderResult{
+                .label   = p->m_name,
+                .icon    = *PICONSENABLED ? p->m_icon : "",
+                .result  = p,
+                .hasIcon = true,
+            });
+        }
+
+        return results;
+    }
+
+    auto fuzzed = Fuzzy::getNResults(m_desktopEntryCacheGeneric, query, MAX_RESULTS_PER_FINDER);
 
     results.reserve(fuzzed.size());
 

--- a/src/query/QueryProcessor.cpp
+++ b/src/query/QueryProcessor.cpp
@@ -97,6 +97,25 @@ void CQueryProcessor::process() {
     bool        eat = false;
 
     if (!m_overrideFinder) {
+        if (query.empty()) {
+            // Only show apps on empty query if configured to do so
+            static auto PSHOWONOPEN = Hyprlang::CSimpleConfigValue<Hyprlang::INT>(g_configManager->m_config.get(), "general:show_apps_on_open");
+            if (*PSHOWONOPEN) {
+                static auto PDEFAULTFINDER = Hyprlang::CSimpleConfigValue<Hyprlang::STRING>(g_configManager->m_config.get(), "finders:default_finder");
+                FINDER                     = finderForName(*PDEFAULTFINDER);
+                if (FINDER) {
+                    auto RESULTS = FINDER->getResultsForQuery("");
+                    if (g_ui && g_ui->m_backend)
+                        g_ui->m_backend->addIdle([r = std::move(RESULTS)] mutable { g_ui->updateResults(std::move(r)); });
+                } else if (g_ui) {
+                    g_ui->m_backend->addIdle([] mutable { g_ui->updateResults({}); });
+                }
+            } else if (g_ui) {
+                g_ui->m_backend->addIdle([] mutable { g_ui->updateResults({}); });
+            }
+            return;
+        }
+
         const auto [F, e] = finderForPrefix(query[0]);
 
         if (e && query.size() == 1)
@@ -106,12 +125,6 @@ void CQueryProcessor::process() {
         eat    = e;
     } else
         FINDER = m_overrideFinder;
-
-    if (query.empty() && !m_overrideFinder) {
-        if (g_ui)
-            g_ui->m_backend->addIdle([] mutable { g_ui->updateResults({}); });
-        return;
-    }
 
     auto RESULTS = FINDER ? FINDER->getResultsForQuery(eat ? query.substr(1) : query) : std::vector<SFinderResult>{};
 


### PR DESCRIPTION
Add a new config option `general:show_apps_on_open` (default: 0) that displays desktop applications sorted by usage frequency when the launcher is opened, without requiring the user to type first.

When disabled (default), the launcher opens with an empty list, preserving the original keyboard-first behavior.