### PR TITLE
feat: show all entries when only a finder prefix is typed1

### DIFF
--- a/src/query/QueryProcessor.cpp
+++ b/src/query/QueryProcessor.cpp
@@ -99,8 +99,16 @@ void CQueryProcessor::process() {
     if (!m_overrideFinder) {
         const auto [F, e] = finderForPrefix(query[0]);
 
-        if (e && query.size() == 1)
+        if (e && query.size() == 1) {
+            // Prefix typed alone: show all results from that finder
+            FINDER = F;
+            if (FINDER) {
+                auto RESULTS = FINDER->getResultsForQuery("");
+                if (g_ui && g_ui->m_backend)
+                    g_ui->m_backend->addIdle([r = std::move(RESULTS)] mutable { g_ui->updateResults(std::move(r)); });
+            }
             return;
+        }
 
         FINDER = F;
         eat    = e;


### PR DESCRIPTION
### Summary
When the user types only a finder prefix (e.g. ' for fonts), the launcher now displays all available results from that finder instead of showing nothing, while respecting the MAX_RESULTS_PER_FINDER limit."

Fixes #144 

### Motivation
Previously, typing just the font prefix caused the launcher to return early without displaying any results — which wasn't intuitive. The expected behavior is that users can browse all available fonts by typing ' alone, without needing to start filtering right away.

### Changes
QueryProcessor.cpp
: when the query contains only the prefix (no additional text), pass an empty query ("") to the selected finder to retrieve all its results, and schedule the UI update via addIdle.

#### How to test
Open hyprlauncher
Type ' (the font finder prefix)
Verify that all available fonts are displayed in the results list