### PR TITLE
Add `--finder [finder]` argument

### DIFF
--- a/protocols/hyprlauncher_core.xml
+++ b/protocols/hyprlauncher_core.xml
@@ -56,8 +56,10 @@
 
     <c2s name="select_finder">
       <description summary="Select the launcher finder">
-            Select the launcher finder. Selecting finder will disable prefixes.
-            When launcher is closed, selected finder is reset.
+            Select the launcher finder, disabling prefixes.
+            If a finder is already selected, it will switch directly
+            to the new finder (it will preserve current search value).
+            Selected finder resets when the launcher is closed.
       </description>
       <arg name="finder" type="varchar" summary="finder name"/>
     </c2s>

--- a/protocols/hyprlauncher_core.xml
+++ b/protocols/hyprlauncher_core.xml
@@ -54,6 +54,14 @@
       <arg name="options" type="array varchar" summary="option array"/>
     </c2s>
 
+    <c2s name="select_finder">
+      <description summary="Select the launcher finder">
+            Select the launcher finder. Selecting finder will disable prefixes.
+            When launcher is closed, selected finder is reset.
+      </description>
+      <arg name="finder" type="varchar" summary="finder name"/>
+    </c2s>
+
     <c2s name="get_info_object">
       <description summary="Get launcher's info object">
             Gets the launcher info object. That object will return some data about

--- a/protocols/hyprlauncher_core.xml
+++ b/protocols/hyprlauncher_core.xml
@@ -59,7 +59,6 @@
             Select the launcher finder, disabling prefixes.
             If a finder is already selected, it will switch directly
             to the new finder (it will preserve current search value).
-            Selected finder resets when the launcher is closed.
       </description>
       <arg name="finder" type="varchar" summary="finder name"/>
     </c2s>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ static void printHelp() {
               << " -d | --daemon              | Do not open after initializing\n"
               << " -o | --options \"a,b,c\"   | Pass an explicit option array\n"
               << " -m | --dmenu               | Pass an option list in dmenu-style (stdin, newline-separated)\n"
+              << " -f | --finder \"math\"     | Use the specified finder\n"
               << " -t | --toggle              | When running with this option, toggle instead of opening\n"
               << " -h | --help                | Print this menu\n"
               << " -v | --version             | Print version info\n"
@@ -64,8 +65,9 @@ static const char* procLockErrorString(CProcLock::eProcLockObtainingError error)
 
 int main(int argc, char** argv, char** envp) {
 
-    bool                     openByDefault = true, dmenuMode = false, toggle = false;
-    std::vector<std::string> explicitOptions;
+    bool                       openByDefault = true, dmenuMode = false, toggle = false;
+    std::vector<std::string>   explicitOptions;
+    std::optional<std::string> selectedFinder;
 
     for (int i = 1; i < argc; ++i) {
         std::string_view sv{argv[i]};
@@ -97,6 +99,13 @@ int main(int argc, char** argv, char** envp) {
             for (const auto& e : vars) {
                 explicitOptions.emplace_back(e);
             }
+            ++i;
+        } else if (sv == "-f" || sv == "--finder") {
+            if (i + 1 >= argc) {
+                Debug::log(ERR, "Missing argument for --finder", sv);
+                return 1;
+            }
+            selectedFinder = argv[i + 1];
             ++i;
         } else if (sv == "-t" || sv == "--toggle") {
             toggle = true;
@@ -132,7 +141,11 @@ int main(int argc, char** argv, char** envp) {
         if (!explicitOptions.empty())
             socket->sendOpenWithOptions(explicitOptions);
         else
+        {
+            if (selectedFinder.has_value())
+                socket->sendSelectFinder(selectedFinder.value());
             toggle ? socket->sendToggle() : socket->sendOpen();
+        }
         return 0;
     }
 
@@ -159,6 +172,8 @@ int main(int argc, char** argv, char** envp) {
     if (!explicitOptions.empty()) {
         g_ipcFinder->setData(explicitOptions);
         g_queryProcessor->overrideQueryProvider(g_ipcFinder.get());
+    } else if (selectedFinder.has_value()) {
+        g_queryProcessor->selectQueryProvider(selectedFinder.value());
     }
 
     g_configManager = makeUnique<CConfigManager>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,9 +65,9 @@ static const char* procLockErrorString(CProcLock::eProcLockObtainingError error)
 
 int main(int argc, char** argv, char** envp) {
 
-    bool                       openByDefault = true, dmenuMode = false, toggle = false;
-    std::vector<std::string>   explicitOptions;
-    std::optional<std::string> selectedFinder;
+    bool                     openByDefault = true, dmenuMode = false, toggle = false;
+    std::vector<std::string> explicitOptions;
+    std::string              selectedFinder = "";
 
     for (int i = 1; i < argc; ++i) {
         std::string_view sv{argv[i]};
@@ -141,8 +141,7 @@ int main(int argc, char** argv, char** envp) {
         if (!explicitOptions.empty())
             socket->sendOpenWithOptions(explicitOptions);
         else {
-            if (selectedFinder.has_value())
-                socket->sendSelectFinder(selectedFinder.value());
+            socket->sendSelectFinder(selectedFinder);
             toggle ? socket->sendToggle() : socket->sendOpen();
         }
         return 0;
@@ -171,8 +170,9 @@ int main(int argc, char** argv, char** envp) {
     if (!explicitOptions.empty()) {
         g_ipcFinder->setData(explicitOptions);
         g_queryProcessor->overrideQueryProvider(g_ipcFinder.get());
-    } else if (selectedFinder.has_value())
-        g_queryProcessor->selectQueryProvider(selectedFinder.value());
+    }
+
+    g_queryProcessor->selectQueryProvider(selectedFinder);
 
     g_configManager = makeUnique<CConfigManager>();
     g_configManager->parse();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,8 +140,7 @@ int main(int argc, char** argv, char** envp) {
         Debug::log(TRACE, "Active instance already, opening launcher.");
         if (!explicitOptions.empty())
             socket->sendOpenWithOptions(explicitOptions);
-        else
-        {
+        else {
             if (selectedFinder.has_value())
                 socket->sendSelectFinder(selectedFinder.value());
             toggle ? socket->sendToggle() : socket->sendOpen();
@@ -172,9 +171,8 @@ int main(int argc, char** argv, char** envp) {
     if (!explicitOptions.empty()) {
         g_ipcFinder->setData(explicitOptions);
         g_queryProcessor->overrideQueryProvider(g_ipcFinder.get());
-    } else if (selectedFinder.has_value()) {
+    } else if (selectedFinder.has_value())
         g_queryProcessor->selectQueryProvider(selectedFinder.value());
-    }
 
     g_configManager = makeUnique<CConfigManager>();
     g_configManager->parse();

--- a/src/query/QueryProcessor.cpp
+++ b/src/query/QueryProcessor.cpp
@@ -14,6 +14,8 @@ static IFinder* finderForName(const std::string& x) {
         return g_unicodeFinder.get();
     if (x == "math")
         return g_mathFinder.get();
+    if (x == "font")
+        return g_fontFinder.get();
     return nullptr;
 }
 

--- a/src/query/QueryProcessor.cpp
+++ b/src/query/QueryProcessor.cpp
@@ -75,7 +75,7 @@ void CQueryProcessor::scheduleQueryUpdate(const std::string& str) {
         std::lock_guard lock(m_mutex);
         m_pendingQuery = SQueryRequest{
             .query      = str,
-            .finder     = m_overrideFinder,
+            .finder     = m_overrideFinder ? m_overrideFinder : m_selectFinder,
             .generation = ++m_generation,
         };
     }
@@ -86,6 +86,13 @@ void CQueryProcessor::scheduleQueryUpdate(const std::string& str) {
 void CQueryProcessor::overrideQueryProvider(IFinder* finder) {
     std::lock_guard lock(m_mutex);
     m_overrideFinder = finder;
+    m_pendingQuery.reset();
+    ++m_generation;
+}
+
+void CQueryProcessor::selectQueryProvider(const std::string& finder) {
+    std::lock_guard lock(m_mutex);
+    m_selectFinder = finderForName(finder);
     m_pendingQuery.reset();
     ++m_generation;
 }

--- a/src/query/QueryProcessor.hpp
+++ b/src/query/QueryProcessor.hpp
@@ -20,6 +20,7 @@ class CQueryProcessor {
 
     void scheduleQueryUpdate(const std::string& str);
     void overrideQueryProvider(IFinder* finder);
+    void selectQueryProvider(const std::string& finder);
 
   private:
     struct SQueryRequest {
@@ -37,6 +38,7 @@ class CQueryProcessor {
     std::thread                  m_queryThread;
     std::optional<SQueryRequest> m_pendingQuery;
     IFinder*                     m_overrideFinder = nullptr;
+    IFinder*                     m_selectFinder   = nullptr;
     uint64_t                     m_generation     = 0;
     bool                         m_quit           = false;
 };

--- a/src/socket/ClientSocket.cpp
+++ b/src/socket/ClientSocket.cpp
@@ -81,3 +81,7 @@ void CClientIPCSocket::sendOpenWithOptions(const std::vector<std::string>& opts)
         ;
     }
 }
+
+void CClientIPCSocket::sendSelectFinder(const std::string& finder) {
+    m_manager->sendSelectFinder(finder.c_str());
+}

--- a/src/socket/ClientSocket.hpp
+++ b/src/socket/ClientSocket.hpp
@@ -16,6 +16,7 @@ class CClientIPCSocket {
     void sendClose();
     void sendToggle();
     void sendOpenWithOptions(const std::vector<std::string>& opts);
+    void sendSelectFinder(const std::string& finder);
 
   private:
     SP<Hyprwire::IClientSocket>         m_socket;

--- a/src/socket/ServerSocket.cpp
+++ b/src/socket/ServerSocket.cpp
@@ -28,6 +28,7 @@ CServerIPCSocket::CServerIPCSocket(const std::string& waylandDisplay) {
 
         manager->setSetOpenState([this](uint32_t state) { setOpenState(state); });
         manager->setOpenWithOptions([this](std::vector<const char*> state) { openWithOptions(state); });
+        manager->setSelectFinder([this](const char* finder) { selectFinder(finder); });
 
         manager->setGetInfoObject([this, m = WP<CHyprlauncherCoreManagerObject>{manager}](uint32_t seq) {
             if (!m)
@@ -66,6 +67,10 @@ void CServerIPCSocket::openWithOptions(const std::vector<const char*>& options) 
     g_ipcFinder->setData(options);
     g_queryProcessor->overrideQueryProvider(g_ipcFinder.get());
     g_ui->setWindowOpen(true);
+}
+
+void CServerIPCSocket::selectFinder(const char* finder) {
+    g_queryProcessor->selectQueryProvider(finder);
 }
 
 void CServerIPCSocket::sendOpenState(bool open) {

--- a/src/socket/ServerSocket.cpp
+++ b/src/socket/ServerSocket.cpp
@@ -71,6 +71,8 @@ void CServerIPCSocket::openWithOptions(const std::vector<const char*>& options) 
 
 void CServerIPCSocket::selectFinder(const char* finder) {
     g_queryProcessor->selectQueryProvider(finder);
+    if (g_ui->windowOpen())
+        g_ui->scheduleQueryRefresh();
 }
 
 void CServerIPCSocket::sendOpenState(bool open) {

--- a/src/socket/ServerSocket.hpp
+++ b/src/socket/ServerSocket.hpp
@@ -18,6 +18,7 @@ class CServerIPCSocket {
   private:
     void                                            setOpenState(uint32_t state);
     void                                            openWithOptions(const std::vector<const char*>& options);
+    void                                            selectFinder(const char* finder);
 
     SP<Hyprwire::IServerSocket>                     m_socket;
 

--- a/src/ui/UI.cpp
+++ b/src/ui/UI.cpp
@@ -169,6 +169,10 @@ void CUI::scheduleQueryUpdate(const std::string& query) {
     g_queryProcessor->scheduleQueryUpdate(query);
 }
 
+void CUI::scheduleQueryRefresh() {
+    scheduleQueryUpdate(std::string(m_inputBox->currentText()));
+}
+
 bool CUI::windowOpen() {
     return m_open;
 }

--- a/src/ui/UI.hpp
+++ b/src/ui/UI.hpp
@@ -32,6 +32,8 @@ class CUI {
 
     void updateActive();
 
+    void scheduleQueryRefresh();
+
   private:
     void                                  onSelected();
     void                                  scheduleQueryUpdate(const std::string& query);


### PR DESCRIPTION
Well, I don't like using prefixes to select a finders. I prefer to have different binds for each finder.

Other users switching from different launchers might have the same issue too. (#155)