### PR TITLE
finders/math: fix copying negative numbers

### DIFF
--- a/src/finders/math/MathFinder.cpp
+++ b/src/finders/math/MathFinder.cpp
@@ -28,7 +28,7 @@ class CMathEntry : public IFinderResult {
     virtual void run() {
         Debug::log(TRACE, "Copying {} with wl-copy", m_result);
 
-        CProcess proc("wl-copy", {m_result});
+        CProcess proc("wl-copy", {"--", m_result});
         proc.runAsync();
     }
 


### PR DESCRIPTION
Currently, `wl-copy` interprets negative numbers as flags. This PR passes `--`
as an argument first to prevent that.
